### PR TITLE
Used reflection to find all IMathOperation subclasses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,14 @@
     <groupId>science.simonstruck</groupId>
     <artifactId>matrixmath</artifactId>
     <version>1.0</version>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.11</version>
+        </dependency>
+    </dependencies>
 
 
 </project>

--- a/src/main/java/matrixmath/MatrixMath.java
+++ b/src/main/java/matrixmath/MatrixMath.java
@@ -1,27 +1,50 @@
 package matrixmath;
 
-import matrixmath.calculations.DeterminantOperation;
 import matrixmath.calculations.IMathOperation;
+import org.reflections.Reflections;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by simon on 20.03.17.
  */
 public class MatrixMath {
-    private static IMathOperation[] operations = {new DeterminantOperation()};
 
     public static void main(String[] args) {
+
+        List<IMathOperation> operations = getOperations();
+
         System.out.println("Welcome to the simple math calculator!");
         while (true) {
             System.out.println();
-            for (int i = 0; i < operations.length; i++) {
-                System.out.println("[" + (i + 1) + "] " + operations[i].getName());
-                System.out.println("\t" + operations[i].getDescription().replaceAll("\n", "\n\t"));
+            for (int i = 0; i < operations.size(); i++) {
+                System.out.println("[" + (i + 1) + "] " + operations.get(i).getName());
+                System.out.println("\t" + operations.get(i).getDescription().replaceAll("\n", "\n\t"));
             }
-            System.out.println("[" + (operations.length + 1) + "] Exit");
+            System.out.println("[" + (operations.size() + 1) + "] Exit");
             int selection = UserInput.getInteger("Please select an action: ");
-            if (selection == operations.length + 1)
+            if (selection == operations.size() + 1)
                 return;
-            operations[selection - 1].execute();
+            operations.get(selection - 1).execute();
         }
+    }
+
+    private static List<IMathOperation> getOperations() {
+        List<IMathOperation> operations = new ArrayList<>();
+
+        Reflections calculationsReflector = new Reflections("matrixmath.calculations");
+        Set<Class<? extends IMathOperation>> classes = calculationsReflector.getSubTypesOf(IMathOperation.class);
+
+        classes.forEach(clazz -> {
+            try {
+                operations.add(clazz.newInstance());
+            } catch (InstantiationException | IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        });
+
+        return operations;
     }
 }


### PR DESCRIPTION
This can be used to reduce merge conflicts since the MatrixMath
class does not need to be edited for each addition. The class is
automatically added (as long as it is in the matrixmath.calculations
package).